### PR TITLE
Improve room list layout

### DIFF
--- a/app/src/main/java/com/example/fhchatroom/screen/ChatRoomListScreen.kt
+++ b/app/src/main/java/com/example/fhchatroom/screen/ChatRoomListScreen.kt
@@ -1,5 +1,7 @@
 package com.example.fhchatroom.screen
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -9,10 +11,13 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Sort
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.Icon
@@ -21,6 +26,7 @@ import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -40,7 +46,6 @@ import com.google.firebase.auth.FirebaseAuth
 
 enum class SortOption(val label: String) {
     NAME("Name"),
-    DESCRIPTION("Description"),
     DATE("Date")
 }
 
@@ -76,20 +81,43 @@ fun ChatRoomListScreen(
 
         Spacer(modifier = Modifier.height(8.dp))
 
-        Row(verticalAlignment = Alignment.CenterVertically) {
-            OutlinedButton(onClick = { sortMenuExpanded = true }) {
-                Text("Sort: ${'$'}{sortOption.label}")
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.clickable { sortMenuExpanded = true }
+            ) {
+                Icon(imageVector = Icons.Filled.Sort, contentDescription = "Sort")
+                Spacer(modifier = Modifier.width(4.dp))
+                Text("Sort")
             }
-            DropdownMenu(expanded = sortMenuExpanded, onDismissRequest = { sortMenuExpanded = false }) {
-                SortOption.values().forEach { option ->
-                    DropdownMenuItem(
-                        text = { Text(option.label) },
-                        onClick = {
-                            sortOption = option
-                            sortMenuExpanded = false
-                        }
-                    )
-                }
+            IconButton(
+                onClick = { showDialog = true },
+                modifier = Modifier
+                    .background(MaterialTheme.colorScheme.primary, CircleShape)
+            ) {
+                Icon(
+                    imageVector = Icons.Filled.Add,
+                    contentDescription = "Create Room",
+                    tint = MaterialTheme.colorScheme.onPrimary
+                )
+            }
+        }
+        DropdownMenu(
+            expanded = sortMenuExpanded,
+            onDismissRequest = { sortMenuExpanded = false }
+        ) {
+            SortOption.values().forEach { option ->
+                DropdownMenuItem(
+                    text = { Text(option.label) },
+                    onClick = {
+                        sortOption = option
+                        sortMenuExpanded = false
+                    }
+                )
             }
         }
 
@@ -101,7 +129,6 @@ fun ChatRoomListScreen(
         }
         val sortedRooms = when (sortOption) {
             SortOption.NAME -> filteredRooms.sortedBy { it.name.lowercase() }
-            SortOption.DESCRIPTION -> filteredRooms.sortedBy { it.description.lowercase() }
             SortOption.DATE -> filteredRooms.sortedBy { it.createdAt }
         }
         LazyColumn {
@@ -134,14 +161,6 @@ fun ChatRoomListScreen(
         }
     }
 
-        Spacer(modifier = Modifier.height(16.dp))
-
-        Button(
-            onClick = { showDialog = true },
-            modifier = Modifier.fillMaxWidth()
-        ) {
-            Text("Create Room")
-        }
         if (showDialog) {
             AlertDialog(
                 onDismissRequest = { showDialog = false },


### PR DESCRIPTION
## Summary
- reposition sort and create room controls under the search field
- remove description option from sorting
- tweak layout so the create-room button is always visible

## Testing
- `./gradlew build -x test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_687909de0ebc832f8d3ff034717ddc10