### PR TITLE
Fix silent message-send failures and missing user profiles

### DIFF
--- a/app/src/main/java/com/example/fhchatroom/data/UserRepository.kt
+++ b/app/src/main/java/com/example/fhchatroom/data/UserRepository.kt
@@ -43,17 +43,35 @@ class UserRepository(
 
 
     suspend fun getCurrentUser(): Result<User> = try {
-        val uid = auth.currentUser?.email
-        if (uid != null) {
+        val firebaseUser = auth.currentUser
+        val email = firebaseUser?.email
+        if (firebaseUser != null && email != null) {
             val userDocument = firestore.collection("users")
-                .document(uid)
+                .document(email)
                 .get()
                 .await()
             val user = userDocument.toObject(User::class.java)
             if (user != null) {
                 Result.Success(user)
             } else {
-                Result.Error(Exception("User data not found"))
+                // Backfill: Firestore profile is missing (can happen if signUp's
+                // second write failed, or the doc was deleted). Reconstruct from
+                // the Firebase Auth profile so the app stays usable.
+                val displayName = firebaseUser.displayName.orEmpty().trim()
+                val (firstName, lastName) = when {
+                    displayName.isEmpty() -> email.substringBefore('@') to ""
+                    displayName.contains(' ') -> {
+                        displayName.substringBefore(' ') to displayName.substringAfter(' ')
+                    }
+                    else -> displayName to ""
+                }
+                val fallback = User(firstName, lastName, email, isOnline = true)
+                try {
+                    saveUserToFirestore(fallback)
+                } catch (_: Exception) {
+                    // Non-fatal: we can still return the in-memory user.
+                }
+                Result.Success(fallback)
             }
         } else {
             Result.Error(Exception("User not authenticated"))

--- a/app/src/main/java/com/example/fhchatroom/viewmodel/MessageViewModel.kt
+++ b/app/src/main/java/com/example/fhchatroom/viewmodel/MessageViewModel.kt
@@ -61,10 +61,32 @@ class MessageViewModel : ViewModel() {
     }
 
     fun sendMessage(text: String, replyToMessage: Message? = null) {
-        if (_currentUser.value != null && _roomId.value != null) {
+        val roomId = _roomId.value
+        if (roomId == null) {
+            _sendResult.value = Error(IllegalStateException("No chat room selected"))
+            Log.e("MessageViewModel", "sendMessage called with null roomId")
+            return
+        }
+
+        viewModelScope.launch {
+            // Ensure we have the current user; retry loading once if it hasn't arrived yet.
+            val user = _currentUser.value ?: run {
+                when (val result = userRepository.getCurrentUser()) {
+                    is Success -> {
+                        _currentUser.value = result.data
+                        result.data
+                    }
+                    is Error -> {
+                        _sendResult.value = Error(result.exception)
+                        Log.e("MessageViewModel", "sendMessage: current user unavailable", result.exception)
+                        return@launch
+                    }
+                }
+            }
+
             val messageData = hashMapOf<String, Any>(
-                "senderFirstName" to _currentUser.value!!.firstName,
-                "senderId" to _currentUser.value!!.email,
+                "senderFirstName" to user.firstName,
+                "senderId" to user.email,
                 "text" to text,
                 "timestamp" to FieldValue.serverTimestamp(),
                 "type" to MessageType.TEXT.name,
@@ -72,10 +94,9 @@ class MessageViewModel : ViewModel() {
                 "deletedFor" to emptyList<String>()
             )
 
-            // Add reply fields if replying
             replyToMessage?.let {
                 messageData["replyToMessageId"] = it.id ?: ""
-                messageData["replyToMessageText"] = when(it.type) {
+                messageData["replyToMessageText"] = when (it.type) {
                     MessageType.IMAGE -> "📷 Photo"
                     MessageType.VOICE -> "🎤 Voice message"
                     else -> it.text.take(100)
@@ -83,18 +104,16 @@ class MessageViewModel : ViewModel() {
                 messageData["replyToSenderName"] = it.senderFirstName
             }
 
-            viewModelScope.launch {
-                try {
-                    firestore.collection("rooms")
-                        .document(_roomId.value!!)
-                        .collection("messages")
-                        .add(messageData)
-                        .await()
-                    _sendResult.value = Success(Unit)
-                } catch (e: Exception) {
-                    _sendResult.value = Error(e)
-                    Log.e("MessageViewModel", "Failed to send message", e)
-                }
+            try {
+                firestore.collection("rooms")
+                    .document(roomId)
+                    .collection("messages")
+                    .add(messageData)
+                    .await()
+                _sendResult.value = Success(Unit)
+            } catch (e: Exception) {
+                _sendResult.value = Error(e)
+                Log.e("MessageViewModel", "Failed to send message", e)
             }
         }
     }


### PR DESCRIPTION
- UserRepository.getCurrentUser now backfills from the Firebase Auth profile when the Firestore users/{email} doc is missing, instead of returning an error that left _currentUser null forever.
- MessageViewModel.sendMessage surfaces errors via _sendResult (null roomId, failed user load) instead of silently no-opping, so the existing ChatScreen toast actually reports the real cause.