### PR TITLE
Fix stuck-online friends list status

### DIFF
--- a/app/src/main/java/com/example/fhchatroom/MainActivity.kt
+++ b/app/src/main/java/com/example/fhchatroom/MainActivity.kt
@@ -100,8 +100,8 @@ class MainActivity : ComponentActivity() {
                     if (email != null) {
                         when (event) {
                             Lifecycle.Event.ON_START -> {
-                                coroutineScope.launch {
-                                    onlineStatusUpdater = OnlineStatusUpdater()
+                                coroutineScope.launch(Dispatchers.IO) {
+                                    onlineStatusUpdater.goOnline()
                                 }
                             }
                             Lifecycle.Event.ON_STOP -> {

--- a/app/src/main/java/com/example/fhchatroom/util/OnlineStatusUpdater.kt
+++ b/app/src/main/java/com/example/fhchatroom/util/OnlineStatusUpdater.kt
@@ -8,105 +8,110 @@ class OnlineStatusUpdater {
     private var connectedListener: ValueEventListener? = null
     private var connRef: DatabaseReference? = null
     private var statusRef: DatabaseReference? = null
+    private var currentEmail: String? = null
 
     private val auth = FirebaseAuth.getInstance()
     private val rtdb = FirebaseDatabase.getInstance()
     private val TAG = "OnlineStatusUpdater-DIAG"
 
-    private val authStateListener = FirebaseAuth.AuthStateListener { auth ->
-        val user = auth.currentUser
-        if (user?.email != null) {
-            Log.d(TAG, "Auth state: user signed in: ${user.email}")
-            setupPresence(user.email!!)
-        } else {
-            Log.d(TAG, "Auth state: user signed out or email is null")
+    private val authStateListener = FirebaseAuth.AuthStateListener { a ->
+        val newEmail = a.currentUser?.email
+        if (newEmail == currentEmail && connectedListener != null) return@AuthStateListener
+        if (newEmail == null) {
+            Log.d(TAG, "Auth state: signed out")
             tearDownPresence()
+            currentEmail = null
+        } else {
+            Log.d(TAG, "Auth state: signed in as $newEmail")
+            tearDownPresence()
+            currentEmail = newEmail
+            setupPresence(newEmail)
         }
     }
 
     init {
         Log.d(TAG, "OnlineStatusUpdater INIT - user=${auth.currentUser?.email}")
         auth.addAuthStateListener(authStateListener)
-        auth.currentUser?.email?.let { setupPresence(it) }
     }
 
     private fun setupPresence(rawEmail: String) {
-        Log.d(TAG, "setupPresence() called for: $rawEmail")
-        tearDownPresence()
+        if (connectedListener != null) {
+            Log.d(TAG, "setupPresence() skipped - already active for $currentEmail")
+            return
+        }
+        Log.d(TAG, "setupPresence() starting for: $rawEmail")
 
-        // Prepare references
         val key = rawEmail.replace(".", ",")
-        Log.d(TAG, "Email key used for RTDB: $key")
         statusRef = rtdb.getReference("status").child(key)
         connRef = rtdb.getReference(".info/connected")
 
-        // Ensure onDisconnect is set
-        statusRef?.onDisconnect()?.setValue(false)
-            ?.addOnSuccessListener { Log.d(TAG, "onDisconnect set to false for $rawEmail") }
-            ?.addOnFailureListener { e -> Log.e(TAG, "Failed to set onDisconnect for $rawEmail", e) }
-
-        // Listen to connection state
+        // The .info/connected listener is the single source of truth for marking
+        // the user online. It fires on every (re)connection, so onDisconnect gets
+        // re-registered against each new socket - necessary because onDisconnect
+        // is bound to a specific socket and doesn't survive reconnects.
         connectedListener = object : ValueEventListener {
             override fun onDataChange(snapshot: DataSnapshot) {
                 val connected = snapshot.getValue(Boolean::class.java) ?: false
-                Log.d(TAG, ".info/connected changed: $connected")
-                if (connected) {
-                    Log.d(TAG, "Connected. Marking user ONLINE in RTDB for $rawEmail")
-                    statusRef?.setValue(true)
-                        ?.addOnSuccessListener { Log.d(TAG, "Set RTDB status = true (online) for $rawEmail") }
-                        ?.addOnFailureListener { e -> Log.e(TAG, "Failed to set RTDB status for $rawEmail", e) }
-                } else {
-                    Log.d(TAG, "Not connected. (Will rely on onDisconnect when needed.)")
-                }
+                Log.d(TAG, ".info/connected = $connected for $rawEmail")
+                if (!connected) return
+                val ref = statusRef ?: return
+                // Fire both writes directly. Don't chain setValue(true) off of
+                // onDisconnect's success callback - if the callback doesn't fire
+                // (e.g., socket drops mid-registration), the user never appears
+                // online even though they're using the app.
+                ref.onDisconnect().setValue(false)
+                    .addOnSuccessListener { Log.d(TAG, "onDisconnect(false) registered for $rawEmail") }
+                    .addOnFailureListener { e -> Log.e(TAG, "onDisconnect register failed for $rawEmail", e) }
+                ref.setValue(true)
+                    .addOnSuccessListener { Log.d(TAG, "status=true written for $rawEmail") }
+                    .addOnFailureListener { e -> Log.e(TAG, "status=true write failed for $rawEmail", e) }
             }
             override fun onCancelled(error: DatabaseError) {
                 Log.e(TAG, ".info/connected listener cancelled", error.toException())
             }
         }
         connRef?.addValueEventListener(connectedListener!!)
+    }
 
-        // Immediately mark online
-        statusRef?.setValue(true)
-            ?.addOnSuccessListener { Log.d(TAG, "Immediate set RTDB status = true (online) for $rawEmail") }
-            ?.addOnFailureListener { e -> Log.e(TAG, "Immediate set failed for $rawEmail", e) }
+    fun goOnline() {
+        val email = auth.currentUser?.email ?: return
+        Log.d(TAG, "goOnline() called for $email")
+        currentEmail = email
+        setupPresence(email)
     }
 
     fun goOffline() {
         val email = auth.currentUser?.email
-        if (email == null) {
-            Log.d(TAG, "goOffline() called, but no user is signed in")
-            return
-        }
         Log.d(TAG, "goOffline() called for $email")
+
+        // Stop listening to connection state - without this, a reconnect event
+        // after the user backgrounds would flip status back to true.
+        connectedListener?.let { connRef?.removeEventListener(it) }
+        connectedListener = null
+
+        statusRef?.onDisconnect()?.cancel()
         statusRef?.setValue(false)
-            ?.addOnSuccessListener { Log.d(TAG, "Set RTDB status = false (offline) for $email") }
-            ?.addOnFailureListener { e -> Log.e(TAG, "Failed to set RTDB status offline for $email", e) }
+            ?.addOnSuccessListener { Log.d(TAG, "status=false written for $email") }
+            ?.addOnFailureListener { e -> Log.e(TAG, "status=false write failed for $email", e) }
     }
 
     private fun tearDownPresence() {
-        Log.d(TAG, "tearDownPresence() called")
         connectedListener?.let { listener ->
             connRef?.removeEventListener(listener)
-            Log.d(TAG, "Removed RTDB .info/connected listener")
         }
         connectedListener = null
 
-        // Cancel onDisconnect and mark offline
         statusRef?.onDisconnect()?.cancel()
-        auth.currentUser?.email?.let { email ->
-            statusRef?.setValue(false)
-                ?.addOnSuccessListener { Log.d(TAG, "Set RTDB status = false (offline) for $email in tearDownPresence()") }
-                ?.addOnFailureListener { e -> Log.e(TAG, "Failed to set offline in tearDownPresence() for $email", e) }
-        }
+        statusRef?.setValue(false)
 
-        // Clear refs
         connRef = null
         statusRef = null
     }
 
     fun cleanup() {
-        Log.d(TAG, "cleanup() called - removing authStateListener and cleaning up presence")
+        Log.d(TAG, "cleanup() called")
         auth.removeAuthStateListener(authStateListener)
         tearDownPresence()
+        currentEmail = null
     }
 }


### PR DESCRIPTION
The presence system had two bugs that made online/offline status unreliable in the Friends list:

1. goOffline() left the .info/connected listener attached, so a reconnect event while the app was backgrounded would flip status back to true - a friend could appear online forever after closing the app. goOffline() now removes the listener and cancels the queued onDisconnect write.

2. ON_START recreated the OnlineStatusUpdater, leaking the previous instance's auth and connection listeners. MainActivity now calls goOnline() on the existing instance instead.

Also made setupPresence idempotent (guarded by connectedListener) so the ON_START path no longer tears down and re-sets a freshly-created presence, which was briefly writing false before re-writing true.

onDisconnect(false) and setValue(true) are now issued directly in parallel from the .info/connected listener rather than chained, so a dropped onDisconnect ack no longer prevents the user from ever appearing online.