### PR TITLE
Add edit message feature

### DIFF
--- a/app/src/main/java/com/example/fhchatroom/data/Message.kt
+++ b/app/src/main/java/com/example/fhchatroom/data/Message.kt
@@ -18,7 +18,8 @@ data class Message(
     val reactions: Map<String, String> = emptyMap(), // userId to emoji
     val replyToMessageId: String? = null, // ID of message being replied to
     val replyToMessageText: String? = null, // Text of original message
-    val replyToSenderName: String? = null // Name of original sender
+    val replyToSenderName: String? = null, // Name of original sender
+    val edited: Boolean = false // True if the message text has been edited
 ) {
     // Helper property to get timestamp as Long for backwards compatibility
     val timestampMillis: Long

--- a/app/src/main/java/com/example/fhchatroom/data/MessageRepository.kt
+++ b/app/src/main/java/com/example/fhchatroom/data/MessageRepository.kt
@@ -6,6 +6,7 @@ import com.google.firebase.firestore.Query
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.tasks.await
 import java.util.Date
 
 class MessageRepository(private val firestore: FirebaseFirestore) {
@@ -60,6 +61,7 @@ class MessageRepository(private val firestore: FirebaseFirestore) {
                             val replyToMessageId = doc.getString("replyToMessageId")
                             val replyToMessageText = doc.getString("replyToMessageText")
                             val replyToSenderName = doc.getString("replyToSenderName")
+                            val edited = doc.getBoolean("edited") ?: false
 
                             Message(
                                 senderFirstName = senderFirstName,
@@ -75,7 +77,8 @@ class MessageRepository(private val firestore: FirebaseFirestore) {
                                 reactions = reactions,
                                 replyToMessageId = replyToMessageId,
                                 replyToMessageText = replyToMessageText,
-                                replyToSenderName = replyToSenderName
+                                replyToSenderName = replyToSenderName,
+                                edited = edited
                             )
                         } catch (e: Exception) {
                             null
@@ -102,5 +105,14 @@ class MessageRepository(private val firestore: FirebaseFirestore) {
             .collection("messages")
             .document(messageId)
             .update("deletedFor", com.google.firebase.firestore.FieldValue.arrayUnion(userEmail))
+    }
+
+    suspend fun editMessage(roomId: String, messageId: String, newText: String) {
+        firestore.collection("rooms")
+            .document(roomId)
+            .collection("messages")
+            .document(messageId)
+            .update(mapOf("text" to newText, "edited" to true))
+            .await()
     }
 }

--- a/app/src/main/java/com/example/fhchatroom/screen/ChatScreen.kt
+++ b/app/src/main/java/com/example/fhchatroom/screen/ChatScreen.kt
@@ -81,6 +81,10 @@ fun ChatScreen(
     var showForwardDialog by remember { mutableStateOf(false) }
     var messageToForward by remember { mutableStateOf<Message?>(null) }
 
+    // Edit state
+    var messageToEdit by remember { mutableStateOf<Message?>(null) }
+    var editText by remember { mutableStateOf("") }
+
     // Search states
     var showSearchBar by remember { mutableStateOf(false) }
     var searchQuery by remember { mutableStateOf("") }
@@ -329,6 +333,10 @@ fun ChatScreen(
                         messageToForward = message
                         showForwardDialog = true
                     },
+                    onEdit = {
+                        messageToEdit = message
+                        editText = message.text
+                    },
                     currentUserId = messageViewModel.currentUser.value?.email ?: ""
                 )
             }
@@ -540,6 +548,50 @@ fun ChatScreen(
         )
     }
 
+    // Edit dialog
+    if (messageToEdit != null) {
+        val editing = messageToEdit!!
+        AlertDialog(
+            onDismissRequest = {
+                messageToEdit = null
+                editText = ""
+            },
+            title = { Text("Edit Message") },
+            text = {
+                OutlinedTextField(
+                    value = editText,
+                    onValueChange = { editText = it },
+                    placeholder = { Text("Message text") },
+                    modifier = Modifier.fillMaxWidth()
+                )
+            },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        val newText = editText.trim()
+                        val messageId = editing.id
+                        if (messageId != null && newText.isNotEmpty() && newText != editing.text) {
+                            messageViewModel.editMessage(roomId, messageId, newText)
+                        }
+                        messageToEdit = null
+                        editText = ""
+                    },
+                    enabled = editText.trim().isNotEmpty() && editText.trim() != editing.text
+                ) {
+                    Text("Save")
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = {
+                    messageToEdit = null
+                    editText = ""
+                }) {
+                    Text("Cancel")
+                }
+            }
+        )
+    }
+
     // Forward dialog
     if (showForwardDialog && messageToForward != null) {
         ForwardMessageDialog(
@@ -587,6 +639,7 @@ fun ChatMessageItem(
     onDelete: () -> Unit = {},
     onDeleteForEveryone: () -> Unit = {},
     onForward: () -> Unit = {},
+    onEdit: () -> Unit = {},
     currentUserId: String = ""
 ) {
     var isPlaying by remember { mutableStateOf(false) }
@@ -767,6 +820,13 @@ fun ChatMessageItem(
                 text = formatTimestamp(message.timestamp),
                 style = TextStyle(fontSize = 12.sp, color = Color.Gray)
             )
+            if (message.edited) {
+                Spacer(modifier = Modifier.width(4.dp))
+                Text(
+                    text = "(edited)",
+                    style = TextStyle(fontSize = 12.sp, color = Color.Gray)
+                )
+            }
         }
 
         // Reaction picker
@@ -864,6 +924,24 @@ fun ChatMessageItem(
                                 Icon(Icons.Default.ContentCopy, contentDescription = "Copy")
                                 Spacer(modifier = Modifier.width(16.dp))
                                 Text("Copy Message")
+                            }
+                        }
+
+                        // Edit (own text messages only)
+                        if (message.type == MessageType.TEXT && message.senderId == currentUserId) {
+                            Row(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .clickable {
+                                        showOptions = false
+                                        onEdit()
+                                    }
+                                    .padding(16.dp),
+                                verticalAlignment = Alignment.CenterVertically
+                            ) {
+                                Icon(Icons.Default.Edit, contentDescription = "Edit")
+                                Spacer(modifier = Modifier.width(16.dp))
+                                Text("Edit Message")
                             }
                         }
 

--- a/app/src/main/java/com/example/fhchatroom/viewmodel/MessageViewModel.kt
+++ b/app/src/main/java/com/example/fhchatroom/viewmodel/MessageViewModel.kt
@@ -377,4 +377,16 @@ class MessageViewModel : ViewModel() {
             messageRepository.deleteMessageForMe(roomId, messageId, userEmail)
         }
     }
+
+    fun editMessage(roomId: String, messageId: String, newText: String) {
+        val trimmed = newText.trim()
+        if (trimmed.isEmpty()) return
+        viewModelScope.launch {
+            try {
+                messageRepository.editMessage(roomId, messageId, trimmed)
+            } catch (e: Exception) {
+                Log.e("MessageViewModel", "Failed to edit message $messageId", e)
+            }
+        }
+    }
 }


### PR DESCRIPTION
Users can long-press their own text messages to reveal an Edit option, modify the content in a dialog, and save. Edited messages show an "(edited)" label next to the timestamp. Editing is restricted to the sender's own text messages; images and voice messages have no edit option.